### PR TITLE
Feat: use committee names for non-candidate-controlled committees

### DIFF
--- a/v2api/create_socrata_csv.py
+++ b/v2api/create_socrata_csv.py
@@ -146,6 +146,7 @@ def get_trans() -> list[dict]:
         offset = offset + body['limit']
         print('\u258a', end='', flush=True)
 
+    print('')
     return results
 
 def get_trans_for_filing(filing_nid, offset=0) -> tuple[list[dict], dict]:
@@ -398,7 +399,7 @@ def df_from_candidates() -> pd.DataFrame:
         'election_year',
         'filer_name',
         'filer_name_local',
-        'committee_type',
+        'jurisdiction',
         'office',
         'start_date',
         'end_date'
@@ -423,7 +424,7 @@ def df_from_candidates() -> pd.DataFrame:
         'SOS ID': 'filer_id',
         'Local Agency ID': 'local_agency_id',
         'Filer Name': 'filer_name_local',
-        'Type': 'committee_type',
+        'Type': 'jurisdiction',
         'contest': 'office',
         'candidate': 'filer_name',
         'start': 'start_date',
@@ -434,7 +435,6 @@ def df_from_candidates() -> pd.DataFrame:
 
     filer_to_cand['end_date'] = pd.to_datetime(filer_to_cand['end_date'])
     filer_to_cand['start_date'] = pd.to_datetime(filer_to_cand['start_date'])
-    filer_to_cand['jurisdiction'] = filer_to_cand.apply(get_jurisdiction, axis=1)
 
     return filer_to_cand
 
@@ -513,18 +513,15 @@ def main(filings, transactions, filers):
     }).rename(columns={
         'filing_nid': 'filing_id'
     })
-    print(df.columns)
     df['filer_name'] = df.apply(
         lambda x: (
             x['filer_name']
-            if x['committee_type'] == 'Candidate or Officeholder'
+            if x['jurisdiction'] == 'Candidate or Officeholder'
             else x['filer_name_local']
         ).strip(),
         axis=1,
         result_type='reduce'
     )
-    print(df['filer_name'].sort_values().unique())
-    df['jurisdiction'] = df['committee_type'] # TODO: Do this when df is created
 
     df.to_csv(f'{EXAMPLE_DATA_DIR}/all_trans.csv', index=False)
 

--- a/v2api/create_socrata_csv.py
+++ b/v2api/create_socrata_csv.py
@@ -398,6 +398,7 @@ def df_from_candidates() -> pd.DataFrame:
         'election_year',
         'filer_name',
         'filer_name_local',
+        'committee_type',
         'office',
         'start_date',
         'end_date'
@@ -422,6 +423,7 @@ def df_from_candidates() -> pd.DataFrame:
         'SOS ID': 'filer_id',
         'Local Agency ID': 'local_agency_id',
         'Filer Name': 'filer_name_local',
+        'Type': 'committee_type',
         'contest': 'office',
         'candidate': 'filer_name',
         'start': 'start_date',
@@ -511,7 +513,18 @@ def main(filings, transactions, filers):
     }).rename(columns={
         'filing_nid': 'filing_id'
     })
-    df['filer_name'] = df['filer_name'].apply(lambda n: n.strip())
+    print(df.columns)
+    df['filer_name'] = df.apply(
+        lambda x: (
+            x['filer_name']
+            if x['committee_type'] == 'Candidate or Officeholder'
+            else x['filer_name_local']
+        ).strip(),
+        axis=1,
+        result_type='reduce'
+    )
+    print(df['filer_name'].sort_values().unique())
+    df['jurisdiction'] = df['committee_type'] # TODO: Do this when df is created
 
     df.to_csv(f'{EXAMPLE_DATA_DIR}/all_trans.csv', index=False)
 
@@ -535,7 +548,7 @@ def main(filings, transactions, filers):
         'receipt_date',
         'election_year',
         'office',
-        'jurisdiction',
+        'jurisdiction', # TODO: Fill jurisdiction with committee type
         'party'
     ]
     contribs = df[df['form'].isin(CONTRIBUTION_FORMS)]

--- a/v2api/create_socrata_csv.py
+++ b/v2api/create_socrata_csv.py
@@ -545,7 +545,7 @@ def main(filings, transactions, filers):
         'receipt_date',
         'election_year',
         'office',
-        'jurisdiction', # TODO: Fill jurisdiction with committee type
+        'jurisdiction',
         'party'
     ]
     contribs = df[df['form'].isin(CONTRIBUTION_FORMS)]


### PR DESCRIPTION
For any committee that is not of type "Candidate or Officeholder" (i.e., "Ballot Measure" and "Not Candidate-controlled" committee types), use the committee name for **filer_name** field. Currently it uses the candidate or measure name for any committee.

Also use **jurisdiction** column for committee type.

E.g.:
```csv
filer_name,jurisdiction
Sheng Thao,Candidate or Officeholder
Working Families for a Better Oakland supporting Sheng Thao for Oakland Mayor 2022,Not Candidate-controlled
```